### PR TITLE
Persist configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,10 @@ If you are interested in the creation of a full project, containing smart contra
 `npm install -g nft-art-generator`
 
 **Usage**
-`nft-generate`
+`nft-generate [--save-config]`
+
+Options
+  - save-config: saves all entered values to a config.json file, which gets used in future runs
 
 **Documentation**  
 

--- a/bin/index.js
+++ b/bin/index.js
@@ -37,6 +37,8 @@ const getDirectories = source =>
     .filter(dirent => dirent.isDirectory())
     .map(dirent => dirent.name);
 
+const sleep = seconds => new Promise(resolve => setTimeout(resolve, seconds * 1000))
+
 //OPENING
 console.log(
   boxen(
@@ -71,35 +73,32 @@ async function main() {
   loadingDirectories.start();
   traits = getDirectories(basePath);
   traitsToSort = [...traits];
-  setTimeout(async () => {
-    loadingDirectories.succeed();
-    loadingDirectories.clear();
-    await traitsOrder(true);
-    await asyncForEach(traits, async trait => {
-      await setNames(trait);
-    });
-    await asyncForEach(traits, async trait => {
-      await setWeights(trait);
-    });
-    await generateImages();
-    const generatingImages = ora('Generating images');
-    generatingImages.color = 'yellow';
-    generatingImages.start();
-    setTimeout(async () => {
-      generatingImages.succeed('All images generated!');
-      generatingImages.clear();
-      if (generateMetadata) {
-        await writeMetadata();
-        const writingMetadata = ora('Exporting metadata');
-        writingMetadata.color = 'yellow';
-        writingMetadata.start();
-        setTimeout(() => {
-          writingMetadata.succeed('Exported metadata successfull');
-          writingMetadata.clear();
-        }, 500);
-      }
-    }, 2000);
-  }, 2000);
+  await sleep(2);
+  loadingDirectories.succeed();
+  loadingDirectories.clear();
+  await traitsOrder(true);
+  await asyncForEach(traits, async trait => {
+    await setNames(trait);
+  });
+  await asyncForEach(traits, async trait => {
+    await setWeights(trait);
+  });
+  await generateImages();
+  const generatingImages = ora('Generating images');
+  generatingImages.color = 'yellow';
+  generatingImages.start();
+  await sleep(2);
+  generatingImages.succeed('All images generated!');
+  generatingImages.clear();
+  if (generateMetadata) {
+    await writeMetadata();
+    const writingMetadata = ora('Exporting metadata');
+    writingMetadata.color = 'yellow';
+    writingMetadata.start();
+    await sleep(0.5);
+    writingMetadata.succeed('Exported metadata successfull');
+    writingMetadata.clear();
+  }
 }
 
 //GET THE BASEPATH FOR THE IMAGES

--- a/bin/index.js
+++ b/bin/index.js
@@ -20,7 +20,7 @@ let outputPath;
 let traits;
 let traitsToSort = [];
 let order = [];
-let weights = [];
+let weights = {};
 let names = {};
 let weightedTraits = [];
 let seen = [];
@@ -229,6 +229,10 @@ async function metadataSettings() {
 
 //SELECT THE ORDER IN WHICH THE TRAITS SHOULD BE COMPOSITED
 async function traitsOrder(isFirst) {
+  if (config.order && config.order.length === traits.length) {
+    order = config.order;
+    return;
+  }
   const traitsPrompt = {
     type: 'list',
     name: 'selected',
@@ -245,6 +249,7 @@ async function traitsOrder(isFirst) {
   });
   const { selected } = await inquirer.prompt(traitsPrompt);
   order.push(selected);
+  config.order = order;
   let localIndex = traitsToSort.indexOf(traits[selected]);
   traitsToSort.splice(localIndex, 1);
   if (order.length === traits.length) return;
@@ -274,6 +279,10 @@ async function setNames(trait) {
 
 //SET WEIGHTS FOR EVERY TRAIT
 async function setWeights(trait) {
+  if (config.weights && Object.keys(config.weights).length === Object.keys(names).length ) {
+    weights = config.weights;
+    return;
+  }
   const files = fs.readdirSync(basePath + '/' + trait);
   const weightPrompt = [];
   files.forEach((file, i) => {
@@ -287,6 +296,7 @@ async function setWeights(trait) {
   files.forEach((file, i) => {
     weights[file] = selectedWeights[names[file] + '_weight'];
   });
+  config.weights = weights;
 }
 
 //ASYNC FOREACH

--- a/bin/index.js
+++ b/bin/index.js
@@ -9,7 +9,7 @@ const boxen = require('boxen');
 const ora = require('ora');
 const inquirer = require('inquirer');
 const fs = require('fs');
-const { readFile, writeFile } = require("fs").promises;
+const { readFile, writeFile, readdir } = require("fs").promises;
 const mergeImages = require('merge-images');
 const { Image, Canvas } = require('canvas');
 const ImageDataURI = require('image-data-uri');
@@ -259,7 +259,7 @@ async function traitsOrder(isFirst) {
 //SET NAMES FOR EVERY TRAIT
 async function setNames(trait) {
   names = config.names || names;
-  const files = fs.readdirSync(basePath + '/' + trait);
+  const files = await getFilesForTrait(trait);
   const namePrompt = [];
   files.forEach((file, i) => {
     if (config.names && config.names[file] !== undefined) return;
@@ -283,7 +283,7 @@ async function setWeights(trait) {
     weights = config.weights;
     return;
   }
-  const files = fs.readdirSync(basePath + '/' + trait);
+  const files = await getFilesForTrait(trait);
   const weightPrompt = [];
   files.forEach((file, i) => {
     weightPrompt.push({
@@ -308,16 +308,16 @@ async function asyncForEach(array, callback) {
 
 //GENERATE WEIGHTED TRAITS
 async function generateWeightedTraits() {
-  traits.forEach(trait => {
+  for (const trait of traits) {
     const traitWeights = [];
-    const files = fs.readdirSync(basePath + '/' + trait);
+    const files = await getFilesForTrait(trait);
     files.forEach(file => {
       for (let i = 0; i < weights[file]; i++) {
         traitWeights.push(file);
       }
     });
     weightedTraits.push(traitWeights);
-  });
+  }
 }
 
 //GENARATE IMAGES
@@ -431,4 +431,8 @@ async function loadConfig() {
 
 async function writeConfig() {
   await writeFile('config.json', JSON.stringify(config, null, 2));
+}
+
+async function getFilesForTrait(trait) {
+  return (await readdir(basePath + '/' + trait)).filter(file => file !== '.DS_Store');
 }

--- a/bin/index.js
+++ b/bin/index.js
@@ -99,11 +99,17 @@ async function main() {
     writingMetadata.color = 'yellow';
     writingMetadata.start();
     await sleep(0.5);
-    writingMetadata.succeed('Exported metadata successfull');
+    writingMetadata.succeed('Exported metadata successfully');
     writingMetadata.clear();
   }
   if (argv['save-config']) {
+    const writingConfig = ora('Saving configuration');
+    writingConfig.color = 'yellow';
+    writingConfig.start();
     await writeConfig();
+    await sleep(0.5);
+    writingConfig.succeed('Saved configuration successfully');
+    writingConfig.clear();
   }
 }
 

--- a/bin/index.js
+++ b/bin/index.js
@@ -86,18 +86,18 @@ async function main() {
   await asyncForEach(traits, async trait => {
     await setWeights(trait);
   });
-  await generateImages();
   const generatingImages = ora('Generating images');
   generatingImages.color = 'yellow';
   generatingImages.start();
+  await generateImages();
   await sleep(2);
   generatingImages.succeed('All images generated!');
   generatingImages.clear();
   if (config.generateMetadata) {
-    await writeMetadata();
     const writingMetadata = ora('Exporting metadata');
     writingMetadata.color = 'yellow';
     writingMetadata.start();
+    await writeMetadata();
     await sleep(0.5);
     writingMetadata.succeed('Exported metadata successfully');
     writingMetadata.clear();

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "image-data-uri": "^2.0.1",
     "inquirer": "^3.3.0",
     "merge-images": "^2.0.0",
+    "minimist": "^1.2.5",
     "ora": "^5.4.1"
   }
 }


### PR DESCRIPTION
- new option `--save-config` which saves all entered values to config.json
- always reads config from config.json
- if new files get added, the relevant value prompts appear again

adresses #3 

Remarks: since the config.json is stored in the same directory as the trait files are, one could also think about making this the default behaviour and remove the option. Maybe better rename it to `nft-art-gen-config.json`.