### PR TITLE
Following a common standard

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -315,7 +315,7 @@ async function generateImages() {
         });
         seen.push(images);
         const b64 = await mergeImages(images, { Canvas: Canvas, Image: Image });
-        await ImageDataURI.outputFile(b64, outputPath + `${id}.png`);
+        await ImageDataURI.outputFile(b64, outputPath + "images/" + `${id}.png`);
         images = [];
         id++;
       }
@@ -329,7 +329,7 @@ async function generateImages() {
       });
       generateMetadataObject(id, images);
       const b64 = await mergeImages(images, { Canvas: Canvas, Image: Image });
-      await ImageDataURI.outputFile(b64, outputPath + `${id}.png`);
+      await ImageDataURI.outputFile(b64, outputPath + "images/" + `${id}.png`);
       images = [];
       id++;
     }
@@ -387,9 +387,15 @@ function generateMetadataObject(id, images) {
 }
 
 async function writeMetadata() {
-  fs.writeFile(outputPath + 'metadata.json', JSON.stringify(metaData), err => {
-    if (err) {
-      throw err;
-    }
-  });
+  let metadata_output_dir = outputPath + "metadata/"
+  if (!fs.existsSync(metadata_output_dir)) {
+    fs.mkdirSync(metadata_output_dir, { recursive: true });
+  }
+  for (var key in metaData){
+    fs.writeFile(metadata_output_dir + key, JSON.stringify(metaData[key]), err => {
+      if (err) {
+        throw err;
+      }
+    });
+  }
 }

--- a/bin/index.js
+++ b/bin/index.js
@@ -225,9 +225,15 @@ async function metadataSettings() {
       name: 'metadataImageUrl',
       message: 'What should be the image url? (Generated format is URL/ID)',
     },
+    {
+      type: 'confirm',
+      name: 'splitFiles',
+      message: 'Should JSON metadata be split in multiple files?',
+    },
   ]);
   config.metaData.name = responses.metadataName;
   config.metaData.description = responses.metadataDescription;
+  config.metaData.splitFiles = responses.splitFiles;
   let lastChar = responses.metadataImageUrl.slice(-1);
   if (lastChar === '/') config.imageUrl = responses.metadataImageUrl;
   else config.imageUrl = responses.metadataImageUrl + '/';
@@ -353,7 +359,7 @@ async function generateImages() {
         });
         seen.push(images);
         const b64 = await mergeImages(images, { Canvas: Canvas, Image: Image });
-        await ImageDataURI.outputFile(b64, outputPath + "images/" + `${id}.png`);
+        await ImageDataURI.outputFile(b64, outputPath + `${id}.png`);
         images = [];
         id++;
       }
@@ -367,7 +373,7 @@ async function generateImages() {
       });
       generateMetadataObject(id, images);
       const b64 = await mergeImages(images, { Canvas: Canvas, Image: Image });
-      await ImageDataURI.outputFile(b64, outputPath + "images/" + `${id}.png`);
+      await ImageDataURI.outputFile(b64, outputPath + `${id}.png`);
       images = [];
       id++;
     }
@@ -425,7 +431,19 @@ function generateMetadataObject(id, images) {
 }
 
 async function writeMetadata() {
-  await writeFile(outputPath + 'metadata.json', JSON.stringify(metaData));
+  if(config.metaData.splitFiles)
+  {
+    let metadata_output_dir = outputPath + "metadata/"
+    if (!fs.existsSync(metadata_output_dir)) {
+      fs.mkdirSync(metadata_output_dir, { recursive: true });
+    }
+    for (var key in metaData){
+      await writeFile(metadata_output_dir + key, JSON.stringify(metaData[key]));
+    }
+  }else
+  {
+    await writeFile(outputPath + 'metadata.json', JSON.stringify(metaData));
+  }
 }
 
 async function loadConfig() {


### PR DESCRIPTION
Changes:
- Added a `metadata/` and `images/` folder
- Removed the `.json` file extension

This is to make it easier to comply to the latest default URI generator by OpenZeppelin
https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC721/ERC721.sol#L92

Cheers!