### PR TITLE
Use filenames instead of custom names for traits

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,10 @@ After that the script will output a list of all traits it could find, and asks y
 When you did this the script, will continue to ask you which trait should be the next layer.  
 Imagine it like the different layers in Photoshop and you are selecting the order of those.
 
-Next you will enter a name for all you files.   
-This names will be used in the Metadata as well as in the script to make weighting the traits easier.  
+The next input lets you decide if you want to use filenames as traits names, or to define custom names for each trait.  
+
+If you selected the last option, you will enter a name for all you files.   
+These names will be used in the Metadata as well as in the script to make weighting the traits easier.  
 Example: If you have a file name bg1.png the script will ask you to name it. If its just a white background you could name it "White".
 
 The next step is the weighting of your traits.  


### PR DESCRIPTION
Let the user decide whether to use file names instead of custom names for traits, as suggested on https://github.com/NotLuksus/nft-art-generator/issues/10.