### PR TITLE
script to help with ipfs workflow

### DIFF
--- a/scripts/ipfs_metadata.py
+++ b/scripts/ipfs_metadata.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+
+# Description: updates the image URL in all .json metadata files of a collection
+
+# How to use: replace INSERT_URL_HERE with the link to where your IPFS images live.
+
+import json
+import os
+
+path_of_dir = "./metadata/"
+
+for filename in os.listdir(path_of_dir):
+  butcher_filename = filename.split(".")
+  token_id = butcher_filename[0]
+  f = os.path.join(path_of_dir, filename)
+  if os.path.isfile(f):
+    rf = open(f, "r")
+    data = json.loads(rf.read())
+    # replace INSERT_URL_HERE with IPFS URL
+    replacement_filename = "INSERT_URL_HERE" + token_id + ".png"
+    data["image"] = replacement_filename
+    wf = open(f, "w")
+    wf.write(json.dumps(data))
+    wf.close()


### PR DESCRIPTION
When hosting an NFT collection on an IPFS gateway, one does not know what link the images will live at until the images are uploaded and a CID is generated for the pinned files. The nft-generate program does not take this into account, and asks for metadata options before the collection is generated.

New workflow when using this script:
1. use nft-generate to generate collection and use placeholder value for the image URL prompt
2. upload images to IPFS gateway; receive public IPFS link to where the images are housed
3. update the ipfs_metadata.py script with the IPFS link from step 2
4. run ipfs_metadata.py script (using Python 3)
5. upload newly updated metadata files to your IPFS gateway
6. happy minting!